### PR TITLE
ci(lint): extend commitlint length

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -30,3 +30,4 @@ policies:
             "release",
           ]
         scopes: [".*"]
+        descriptionLength: 92


### PR DESCRIPTION
The default conventional commit description length is 72, which has proven to be to short for automatic tooling, like renovate sometimes. So, raising this to avoid future lint fails.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
