### PR TITLE
feat: add support for optional key attestations

### DIFF
--- a/Wallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git",
       "state" : {
-        "revision" : "f08783f37364bb300ee32182fd0b7dfc9c29dfd4",
-        "version" : "0.20.0"
+        "revision" : "be60de2e1587ec5691d9fdc69b9cad749db71860",
+        "version" : "0.33.0"
       }
     },
     {

--- a/Wallet/Core/Networking/Gateway/GatewayApiClient.swift
+++ b/Wallet/Core/Networking/Gateway/GatewayApiClient.swift
@@ -16,7 +16,7 @@ protocol GatewayApi: Sendable {
     jwk: JWK,
   ) async throws -> String
 
-  func getWalletUnitAttestation(nonce: String) async throws -> String
+  func getWalletUnitAttestation(nonce: String?) async throws -> String
 }
 
 struct GatewayApiClient: GatewayApi {
@@ -58,7 +58,7 @@ struct GatewayApiClient: GatewayApi {
   }
 
   func getWalletUnitAttestation(
-    nonce: String,
+    nonce: String?,
   ) async throws -> String {
     let nonceQuery = Operations.CreateWua.Input.Query(nonce: nonce)
     let input = Operations.CreateWua.Input(query: nonceQuery)

--- a/Wallet/Core/Networking/Gateway/GatewayApiMock.swift
+++ b/Wallet/Core/Networking/Gateway/GatewayApiMock.swift
@@ -15,7 +15,7 @@ struct GatewayApiMock: GatewayApi {
     ""
   }
 
-  func getWalletUnitAttestation(nonce: String) throws -> String {
+  func getWalletUnitAttestation(nonce: String?) throws -> String {
     ""
   }
 }

--- a/Wallet/Features/Issuance/IssuanceModels.swift
+++ b/Wallet/Features/Issuance/IssuanceModels.swift
@@ -10,8 +10,8 @@ import OpenID4VCI
 
 struct CredentialRequest: Codable {
   let credentialConfigurationId: String
-  let credentialResponseEncryption: CredentialResponseEncryptionDTO?
   let proofs: JwtProofType
+  let credentialResponseEncryption: CredentialResponseEncryptionDTO?
 
   enum CodingKeys: String, CodingKey {
     case credentialConfigurationId = "credential_configuration_id"
@@ -25,8 +25,8 @@ struct CredentialRequest: Codable {
     credentialResponseEncryption: CredentialResponseEncryptionDTO? = nil
   ) {
     self.credentialConfigurationId = credentialConfigurationId
-    self.credentialResponseEncryption = credentialResponseEncryption
     self.proofs = proofs
+    self.credentialResponseEncryption = credentialResponseEncryption
   }
 }
 
@@ -51,16 +51,10 @@ struct CredentialBody: Codable {
   let credential: String
 }
 
-struct PidClaim: Identifiable {
-  let id = UUID()
-  let claim: Claim
-  // Parse value into correct format based on claim.value_type
-  let value: String
-}
-
 struct JwtProofPayload: Codable {
-  let nonce: String?
   let aud: String
+  let nonce: String?
+  var iss: String? = "wallet-app"
 }
 
 struct KeyAttestationHeader: JWSRegisteredFieldsHeader {

--- a/Wallet/Features/Issuance/IssuanceViewModel.swift
+++ b/Wallet/Features/Issuance/IssuanceViewModel.swift
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import AuthenticationServices
-import Crypto
 import Foundation
-import JSONWebAlgorithms
-import JSONWebKey
 import OpenID4VCI
 import WalletMacros
 import eudi_lib_sdjwt_swift
@@ -20,7 +17,6 @@ enum IssuanceState {
 
 @MainActor
 @Observable
-// swiftlint:disable:next type_body_length
 class IssuanceViewModel {
   private let credentialOfferUri: String
   private(set) var claimsMetadata: [String: String] = [:]
@@ -60,15 +56,12 @@ class IssuanceViewModel {
         throw IssuanceError.issuerNotFound
       }
 
-      let prepared = try await issuer.prepareAuthorizationRequest(credentialOffer: credentialOffer)
-        .get()
-
-      guard case let .prepared(data) = prepared else {
-        throw IssuanceError.authRequestFailed
-      }
+      let preparedRequest = try await issuer.prepareAuthorizationRequest(
+        credentialOffer: credentialOffer
+      )
 
       let oAuthCallback = try await oauth.start(
-        url: data.authorizationCodeURL.url,
+        url: preparedRequest.authorizationCodeURL.url,
         callbackScheme: "wallet-app",
         anchor: authPresentationAnchor,
       )
@@ -77,28 +70,26 @@ class IssuanceViewModel {
         throw IssuanceError.invalidAuth
       }
 
-      let requestWithAuthCode =
-        try await issuer.handleAuthorizationCode(
-          request: prepared,
-          authorizationCode: .init(authorizationCode: code),
-        )
-        .get()
+      let authCodeReceived = try await issuer.handleAuthorizationCode(
+        request: preparedRequest,
+        authorizationCode: .init(authorizationCode: code),
+      )
 
-      let issuanceState = data.state
-      let authCodeUrl = await issuer.issuerMetadata.authorizationServers?.first
+      let authorizationServer = await issuer.issuerMetadata.authorizationServers?.first
+      let issuerState = oAuthCallback.queryItemValue(for: "state") ?? preparedRequest.state
 
       let authResponse =
         try await issuer
         .authorizeWithAuthorizationCode(
-          request: requestWithAuthCode,
+          request: authCodeReceived,
+          preparedRequest: preparedRequest,
           grant: .authorizationCode(
             .init(
-              issuerState: issuanceState,
-              authorizationServer: authCodeUrl,
+              issuerState: issuerState,
+              authorizationServer: authorizationServer,
             )
           ),
         )
-        .get()
 
       state = .authorized(request: authResponse)
       await fetchCredential(authResponse)
@@ -113,42 +104,43 @@ class IssuanceViewModel {
         throw IssuanceError.issuerNotFound
       }
 
+      let metadata = await issuer.issuerMetadata
+
       guard
         let configId = credentialOffer?.credentialConfigurationIdentifiers.first,
-        let supportedCredential = await issuer.issuerMetadata.credentialsSupported[configId],
-        case let .sdJwtVc(config) = supportedCredential,
-        let jwtProofType = supportedCredential.proofTypesSupported?["jwt"]
+        let supportedCredential = metadata.credentialsSupported[configId],
+        case let .sdJwtVc(credentialConfig) = supportedCredential,
+        let proofTypeJwt = credentialConfig.proofTypesSupported?["jwt"]
       else {
         throw IssuanceError.credentialNotSupported
       }
 
-      let jwtProof = try await createProof(issuer)
-      let requestEncryption = await issuer.issuerMetadata.credentialRequestEncryption.toCryptoSpec()
-      let url = await issuer.issuerMetadata.credentialEndpoint.url
-      let accessToken = authRequest.accessToken.accessToken
+      let keyAttestationRequired =
+        switch proofTypeJwt.keyAttestationRequirement {
+          case .required, .requiredNoConstraints: true
+          default: false
+        }
 
-      let credential: String
-      if let requestEncryption {
-        credential = try await fetchEncryptedCredential(
-          requestEncryption: requestEncryption,
-          jwtProof: jwtProof,
-          configId: configId.value,
-          url: url,
-          accessToken: accessToken,
-        )
-      } else {
-        credential = try await fetchUnencryptedCredential(
-          jwtProof: jwtProof,
-          configId: configId.value,
-          url: url,
-          accessToken: accessToken,
-        )
-      }
+      let jwtProof = try await createProof(
+        issuerId: metadata.credentialIssuerIdentifier.url.absoluteString,
+        keyAttestationRequired: keyAttestationRequired,
+        nonceUrl: metadata.nonceEndpoint?.url,
+      )
 
-      let display = await issuer.issuerMetadata.display.first
+      let credential = try await openId4VciUtil.fetchCredential(
+        url: metadata.credentialEndpoint.url,
+        token: authRequest.accessToken.accessToken,
+        credentialRequest: CredentialRequest(
+          credentialConfigurationId: configId.value,
+          proofs: JwtProofType(jwt: [jwtProof]),
+        ),
+        requestEncryption: metadata.credentialRequestEncryption.toCryptoSpec(),
+      )
+
+      let display = metadata.display.first
       let parsedCredential = try parseCredential(
         credential,
-        credentialConfiguration: config,
+        credentialConfiguration: credentialConfig,
         issuer: display,
       )
 
@@ -158,73 +150,35 @@ class IssuanceViewModel {
     }
   }
 
-  private func createProof(_ issuer: Issuer) async throws -> String {
-    let aud = await issuer.issuerMetadata.credentialIssuerIdentifier.url.absoluteString
-    let payload: JwtProofPayload
-    let keyAttestation: String?
-    if let nonceURL = await issuer.issuerMetadata.nonceEndpoint?.url {
-      let nonce = try await openId4VciUtil.fetchNonce(url: nonceURL)
-      keyAttestation = try await gatewayApiClient.getWalletUnitAttestation(nonce: nonce)
-      payload = JwtProofPayload(nonce: nonce, aud: aud)
-    } else {
-      keyAttestation = nil
-      payload = JwtProofPayload(nonce: nil, aud: aud)
-    }
+  private func createProof(
+    issuerId: String,
+    keyAttestationRequired: Bool,
+    nonceUrl: URL?,
+  ) async throws -> String {
+    let nonce: String? =
+      if let nonceUrl {
+        try await openId4VciUtil.fetchNonce(url: nonceUrl)
+      } else {
+        nil
+      }
+
+    let keyAttestation: String? =
+      if keyAttestationRequired {
+        try await gatewayApiClient.getWalletUnitAttestation(nonce: nonce)
+      } else {
+        nil
+      }
+
+    let payload = JwtProofPayload(aud: issuerId, nonce: nonce)
+    let key = try SigningKeyStore.getOrCreateKey(withTag: .walletKey)
 
     return try jwtUtil.signJwt(
       with: SigningKeyStore.getOrCreateKey(withTag: .walletKey),
       payload: payload,
-      header: KeyAttestationHeader(keyAttestation: keyAttestation),
-    )
-  }
-
-  private func fetchEncryptedCredential(
-    requestEncryption: CryptoSpec,
-    jwtProof: String,
-    configId: String,
-    url: URL,
-    accessToken: String,
-  ) async throws -> String {
-    let key = P256.KeyAgreement.PrivateKey()
-    var jwk = key.publicKey.jwkRepresentation
-    jwk.algorithm = KeyManagementAlgorithm.ecdhES.rawValue
-    let enc: ContentEncryptionAlgorithm = .a128GCM
-    let credentialRequest = CredentialRequest(
-      credentialConfigurationId: configId,
-      proofs: JwtProofType(jwt: [jwtProof]),
-      credentialResponseEncryption: CredentialResponseEncryptionDTO(
-        jwk: jwk,
-        enc: enc.rawValue,
+      header: KeyAttestationHeader(
+        jwk: keyAttestationRequired ? nil : key.publicKey.jwk,
+        keyAttestation: keyAttestation,
       ),
-    )
-
-    return try await openId4VciUtil.fetchCredential(
-      url: url,
-      token: accessToken,
-      credentialRequest: credentialRequest,
-      requestEncryption: requestEncryption,
-      responseDecryption: CryptoSpec(
-        key: key.jwkRepresentation,
-        enc: enc,
-      ),
-    )
-  }
-
-  private func fetchUnencryptedCredential(
-    jwtProof: String,
-    configId: String,
-    url: URL,
-    accessToken: String,
-  ) async throws -> String {
-    let credentialRequest = CredentialRequest(
-      credentialConfigurationId: configId,
-      proofs: JwtProofType(jwt: [jwtProof]),
-    )
-
-    return try await openId4VciUtil.fetchCredential(
-      url: url,
-      token: accessToken,
-      credentialRequest: credentialRequest,
     )
   }
 

--- a/Wallet/Features/Issuance/OpenId4VciUtil.swift
+++ b/Wallet/Features/Issuance/OpenId4VciUtil.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import Crypto
 import Foundation
 import JSONWebAlgorithms
 import JSONWebKey
@@ -18,32 +19,36 @@ struct OpenId4VciUtil {
   func fetchCredential(
     url: URL,
     token: String,
-    credentialRequest: CredentialRequest
+    credentialRequest: CredentialRequest,
+    requestEncryption: CryptoSpec? = nil
   ) async throws -> String {
-    let response: CredentialResponse = try await NetworkClient.fetch(
-      url,
-      method: .post,
-      token: token,
-      body: try encoder.encode(credentialRequest)
-    )
-    guard let credential = response.credentials.first else {
-      throw AppError(reason: "Could not fetch credential")
+    guard let requestEncryption else {
+      return try await fetchPlainCredential(
+        url: url,
+        token: token,
+        credentialRequest: credentialRequest
+      )
     }
 
-    return credential.credential
-  }
+    let ephemeralKey = P256.KeyAgreement.PrivateKey()
+    let enc = requestEncryption.enc
 
-  func fetchCredential(
-    url: URL,
-    token: String,
-    credentialRequest: CredentialRequest,
-    requestEncryption: CryptoSpec,
-    responseDecryption: CryptoSpec,
-  ) async throws -> String {
+    var responseJwk = ephemeralKey.publicKey.jwkRepresentation
+    responseJwk.algorithm = KeyManagementAlgorithm.ecdhES.rawValue
+
+    let encryptedRequest = CredentialRequest(
+      credentialConfigurationId: credentialRequest.credentialConfigurationId,
+      proofs: credentialRequest.proofs,
+      credentialResponseEncryption: CredentialResponseEncryptionDTO(
+        jwk: responseJwk,
+        enc: enc.rawValue
+      )
+    )
+
     let jwe = try jwtUtil.encryptJwe(
-      payload: credentialRequest,
+      payload: encryptedRequest,
       recipientKey: requestEncryption.key,
-      enc: requestEncryption.enc
+      enc: enc
     )
 
     let encryptedResponse = try await NetworkClient.fetchJwt(
@@ -57,9 +62,27 @@ struct OpenId4VciUtil {
 
     let response: CredentialResponse = try jwtUtil.decryptJwe(
       encryptedResponse,
-      decryptionKey: responseDecryption.key
+      decryptionKey: ephemeralKey.jwkRepresentation
     )
 
+    guard let credential = response.credentials.first else {
+      throw AppError(reason: "Could not fetch credential")
+    }
+
+    return credential.credential
+  }
+
+  private func fetchPlainCredential(
+    url: URL,
+    token: String,
+    credentialRequest: CredentialRequest
+  ) async throws -> String {
+    let response: CredentialResponse = try await NetworkClient.fetch(
+      url,
+      method: .post,
+      token: token,
+      body: try encoder.encode(credentialRequest)
+    )
     guard let credential = response.credentials.first else {
       throw AppError(reason: "Could not fetch credential")
     }

--- a/project.yml
+++ b/project.yml
@@ -56,7 +56,7 @@ packages:
     exactVersion: 0.19.0
   eudi-lib-ios-openid4vci-swift:
     url: https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vci-swift.git
-    exactVersion: 0.20.0
+    exactVersion: 0.33.0
   eudi-lib-sdjwt-swift:
     url: https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift.git
     exactVersion: 0.13.1


### PR DESCRIPTION
Makes key attestation optional if not required in OpenId4VCI.

Moves fetchCredential logic into OpenId4VciUtil instead of keeping it in view model.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
