### PR TITLE
ci: skip swiftlint for release builds

### DIFF
--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -6,6 +6,11 @@
 
 set -e
 
+if [ "$CONFIGURATION" = "Release" ]; then
+  echo "Skipping SwiftLint for Release build"
+  exit 0
+fi
+
 export PATH="$HOME/.local/share/mise/shims:/opt/homebrew/bin:$PATH"
 
 if ! command -v swiftlint &>/dev/null; then


### PR DESCRIPTION
# Pull Request Description

Skip SwiftLint for release builds as it is already checked pre-merge.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
