### PR TITLE
ci: bump reusable-ci to 2.8.0 (was 2.7.9)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -8,7 +8,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: sudo xcode-select -s /Applications/Xcode_${{ inputs.xcode-version }}.app
+    - env:
+        XCODE_VERSION: ${{ inputs.xcode-version }}
+      run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
       shell: bash
 
     - run: brew install bash

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -20,4 +20,4 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@a89d880d9a859491c09c300428caa17c9644b39b # v2.8.0

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -16,14 +16,14 @@ concurrency:
 
 jobs:
   pr-checks:
-    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@a89d880d9a859491c09c300428caa17c9644b39b # v2.8.0
     permissions:
       contents: read
       packages: read
       security-events: write
     secrets: inherit
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: v2.8.0
       project-type: xcode-ios
       linters.devbasecheck: true
       linters.megalint: false

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -37,12 +37,12 @@ jobs:
 
   build:
     needs: build-number
-    uses: diggsweden/reusable-ci/.github/workflows/build-xcode-ios.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/build-xcode-ios.yml@a89d880d9a859491c09c300428caa17c9644b39b # v2.8.0
     permissions:
       contents: read
     secrets: inherit
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: v2.8.0
       xcode-version: "26.2"
       scheme: "Wallet Demo"
       workspace: "Wallet.xcworkspace"
@@ -56,13 +56,13 @@ jobs:
 
   upload-testflight:
     needs: build
-    uses: diggsweden/reusable-ci/.github/workflows/publish-apple-appstore.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/publish-apple-appstore.yml@a89d880d9a859491c09c300428caa17c9644b39b # v2.8.0
 
     permissions:
       contents: read
     secrets: inherit
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: v2.8.0
       ipa-artifact-name: wallet-ios-demo-dev
       submit-for-review: false
       skip-validation: false

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -46,7 +46,7 @@ jobs:
 
   release:
     needs: generate-artifacts-config
-    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@a89d880d9a859491c09c300428caa17c9644b39b # v2.8.0
     permissions:
       contents: write
       packages: write
@@ -56,7 +56,7 @@ jobs:
       actions: read
     secrets: inherit
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: v2.8.0
       artifacts-config: ${{ needs.generate-artifacts-config.outputs.config }}
       release-publisher: github-cli
       release.attachartifacts: |


### PR DESCRIPTION
* fix: move xcode version input into ENV in setup-env action

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
