### PR TITLE
chore: move schema typealiases to single file and update scaffolding

### DIFF
--- a/Wallet/Core/Models/CredentialType.swift
+++ b/Wallet/Core/Models/CredentialType.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import Foundation
-import SwiftData
 
-typealias User = SchemaV2.User
+enum CredentialType: String, Codable, Sendable {
+  case pid = "urn:eudi:pid:1"
+}

--- a/Wallet/Core/Persistence/CurrentModels.swift
+++ b/Wallet/Core/Persistence/CurrentModels.swift
@@ -7,7 +7,4 @@ import Foundation
 typealias IssuerDisplay = SchemaV2.IssuerDisplay
 typealias SavedCredential = SchemaV2.SavedCredential
 typealias CredentialDisplayData = SchemaV2.CredentialDisplayData
-
-enum CredentialType: String, Codable, Sendable {
-  case pid = "urn:eudi:pid:1"
-}
+typealias User = SchemaV2.User

--- a/scripts/swift/SwiftDataMigrate/Sources/Configuration.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/Configuration.swift
@@ -10,6 +10,7 @@ enum Config {
   static let schemaDirectory = "Wallet/Core/Persistence/Schema"
   static let migrationDirectory = "Wallet/Core/Persistence/Migration"
   static let testsDirectory = "WalletTests/Persistence"
+  static let currentModelsFile = "Wallet/Core/Persistence/CurrentModels.swift"
 
   static let migrationPlanFilename = "SwiftDataMigrationPlan.swift"
 

--- a/scripts/swift/SwiftDataMigrate/Sources/ProjectContext.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/ProjectContext.swift
@@ -10,6 +10,7 @@ struct ProjectContext {
   let migrationDir: URL
   let testsDir: URL
   let planFile: URL
+  let currentModelsFile: URL
   let existingVersions: [Int]
 
   var latestVersion: Int { existingVersions.last ?? .zero }
@@ -23,6 +24,7 @@ struct ProjectContext {
     let migrationDir = repoRoot.appendingPathComponent(Config.migrationDirectory)
     let testsDir = repoRoot.appendingPathComponent(Config.testsDirectory)
     let planFile = migrationDir.appendingPathComponent(Config.migrationPlanFilename)
+    let currentModelsFile = repoRoot.appendingPathComponent(Config.currentModelsFile)
 
     for dir in [schemaDir, migrationDir, testsDir] {
       var isDir: ObjCBool = false
@@ -31,12 +33,17 @@ struct ProjectContext {
       }
     }
 
+    guard FileManager.default.fileExists(atPath: currentModelsFile.path) else {
+      throw SwiftDataMigrationError.fileMissing(path: currentModelsFile.path)
+    }
+
     return ProjectContext(
       repoRoot: repoRoot,
       schemaDir: schemaDir,
       migrationDir: migrationDir,
       testsDir: testsDir,
       planFile: planFile,
+      currentModelsFile: currentModelsFile,
       existingVersions: try discoverAllSchemaVersions(in: schemaDir)
     )
   }

--- a/scripts/swift/SwiftDataMigrate/Sources/Scaffolder.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/Scaffolder.swift
@@ -9,7 +9,6 @@ final class Scaffolder {
 
   private let nextVersion: Int
   private let stageKind: StageKind
-  private(set) var typealiasFilesUpdated: [URL] = []
 
   init(context: ProjectContext, nextVersion: Int, stageKind: StageKind) {
     self.context = context
@@ -110,10 +109,9 @@ private extension Scaffolder {
     let bumper = TypealiasBumper(
       fromVersion: prevVersion,
       toVersion: nextVersion,
-      repoRoot: context.repoRoot,
-      excludeDirectory: context.schemaDir
+      file: context.currentModelsFile
     )
-    typealiasFilesUpdated = try bumper.run()
+    try bumper.run()
   }
   
   func ensureDoesNotExist(_ url: URL) throws {

--- a/scripts/swift/SwiftDataMigrate/Sources/SwiftDataMigrationError.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/SwiftDataMigrationError.swift
@@ -11,6 +11,7 @@ enum SwiftDataMigrationError: Error, CustomStringConvertible {
   case prevVersionWasZero
   case invalidHeader(path: String)
   case xcodegenFailed(exitCode: Int32)
+  case fileMissing(path: String)
 
   var description: String {
     switch self {
@@ -26,6 +27,8 @@ enum SwiftDataMigrationError: Error, CustomStringConvertible {
       "File does not start with the expected header: \(path)"
     case let .xcodegenFailed(exitCode):
       "xcodegen failed with exit code \(exitCode)"
+    case let .fileMissing(path):
+      "Required file does not exist: \(path)"
     }
   }
 }

--- a/scripts/swift/SwiftDataMigrate/Sources/TypealiasBumper.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/TypealiasBumper.swift
@@ -7,66 +7,17 @@ import Foundation
 struct TypealiasBumper {
   let fromVersion: Int
   let toVersion: Int
-  let repoRoot: URL
-  let excludeDirectory: URL
+  let file: URL
 
-  private var current: String { "SchemaV\(fromVersion)\\." }
-  private var replacement: String { "SchemaV\(toVersion)." }
-
-  func run() throws -> [URL] {
-    var updatedFiles: [URL] = []
-    for url in swiftFiles() {
-      if try rewriteTypealiases(in: url) {
-        updatedFiles.append(url)
-      }
-    }
-    return updatedFiles
-  }
-
-  private func swiftFiles() -> [URL] {
-    guard let enumerator = FileManager.default.enumerator(
-      at: repoRoot,
-      includingPropertiesForKeys: [.isRegularFileKey],
-      options: [.skipsHiddenFiles, .skipsPackageDescendants]
-    ) else { return [] }
-
-    var results: [URL] = []
-    for case let url as URL in enumerator {
-      guard url.pathExtension == "swift" else { continue }
-      guard !url.path.hasPrefix(excludeDirectory.path) else { continue }
-      results.append(url)
-    }
-    return results
-  }
-
-  private func rewriteTypealiases(in url: URL) throws -> Bool {
-    let content = try String(contentsOf: url, encoding: .utf8)
-    let lines = content.components(separatedBy: "\n")
-
-    var updatedLines = lines
-    var changed = false
-
-    for (index, line) in lines.enumerated() {
-      guard isTypealiasLine(line) else { continue }
-
-      let updated = line.replacingOccurrences(
-        of: current,
-        with: replacement,
-        options: .regularExpression
-      )
-      if updated != line {
-        updatedLines[index] = updated
-        changed = true
-      }
-    }
-
-    if changed {
-      try updatedLines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
-    }
-    return changed
-  }
-
-  private func isTypealiasLine(_ line: String) -> Bool {
-    line.trimmingCharacters(in: .whitespaces).hasPrefix("typealias ")
+  @discardableResult
+  func run() throws -> Bool {
+    let original = try String(contentsOf: file, encoding: .utf8)
+    let updated = original.replacingOccurrences(
+      of: "SchemaV\(fromVersion).",
+      with: "SchemaV\(toVersion)."
+    )
+    guard updated != original else { return false }
+    try updated.write(to: file, atomically: true, encoding: .utf8)
+    return true
   }
 }

--- a/scripts/swift/SwiftDataMigrate/Sources/main.swift
+++ b/scripts/swift/SwiftDataMigrate/Sources/main.swift
@@ -60,7 +60,7 @@ struct NewCommand: ParsableCommand {
       Created: \(Config.migrationDirectory)/MigrateV\(prev)toV\(nextVersion).swift
       Created: \(Config.testsDirectory)/MigrateV\(prev)toV\(nextVersion)Tests.swift
       Updated: \(Config.migrationDirectory)/\(Config.migrationPlanFilename)
-      Updated: \(scaffold.typealiasFilesUpdated.count) file(s) with bumped typealiases
+      Updated: \(Config.currentModelsFile)
 
     Next steps:
       1. Edit SchemaV\(nextVersion).swift to make your schema changes


### PR DESCRIPTION
# Pull Request Description

Schema-model typealiases are moved to a single file for easier maintenance. Scaffolding updates with it.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

## Media (validation)

https://github.com/user-attachments/assets/3257b6a7-7537-41e0-9dbb-55099a9d992e



