### PR TITLE
fix: add missing directory identifier in xcode refresh workflow

### DIFF
--- a/.github/workflows/refresh-xcode-cache.yml
+++ b/.github/workflows/refresh-xcode-cache.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Environment
-        uses: ./github/actions/setup-env
+        uses: ./.github/actions/setup-env
 
       - name: Build Xcode
         uses: ./.github/actions/xcode-build


### PR DESCRIPTION
# Pull Request Description

This PR adds a missing directory identifier in xcode refresh workflow

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
