### PR TITLE
fix: use consistent scheme for xcode cache

### DIFF
--- a/.github/actions/xcode-build/action.yml
+++ b/.github/actions/xcode-build/action.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: Xcode Build
-description: Restore Xcode cache, generate project, and build the Xcode project
+description: Restore Xcode cache, generate project, and build for testing to warm the cache
 
 runs:
   using: composite
@@ -19,8 +19,8 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        xcodebuild build \
+        xcodebuild build-for-testing \
           -workspace Wallet.xcworkspace \
-          -scheme Wallet \
+          -scheme WalletTests \
           -destination 'platform=iOS Simulator,name=iPhone 17' \
         | xcbeautify

--- a/.github/workflows/refresh-xcode-cache.yml
+++ b/.github/workflows/refresh-xcode-cache.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Refresh or save Xcode cache
         if: success()
-        uses: ./github/actions/xcode-cache-save
+        uses: ./.github/actions/xcode-cache-save


### PR DESCRIPTION
# Pull Request Description

This PR ensures that we use a consistent build & scheme between the pull request workflow and the Xcode cache workflow

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
