### PR TITLE
ci: pin commit hashes for actions and add .semgrepignore

### DIFF
--- a/.github/actions/xcode-cache-restore/action.yml
+++ b/.github/actions/xcode-cache-restore/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Restore Xcode DerivedData cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           Wallet.xcodeproj

--- a/.github/actions/xcode-cache-save/action.yml
+++ b/.github/actions/xcode-cache-save/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Save Xcode DerivedData cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           Wallet.xcodeproj

--- a/.github/actions/xcode-coverage-report/action.yml
+++ b/.github/actions/xcode-coverage-report/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Upload coverage report
       if: hashFiles('coverage-files.txt') != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/workflows/compute-build-number.yml
+++ b/.github/workflows/compute-build-number.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       value: ${{ steps.compute.outputs.number }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - name: Compute build number from main commit count

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    secrets: inherit
+    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       project-type: xcode-ios
@@ -38,7 +38,7 @@ jobs:
     needs: pr-checks
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
+    secrets: inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       project-type: xcode-ios

--- a/.github/workflows/refresh-xcode-cache.yml
+++ b/.github/workflows/refresh-xcode-cache.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -40,7 +40,7 @@ jobs:
     uses: diggsweden/reusable-ci/.github/workflows/build-xcode-ios.yml@d31c989acd139c3e8754e116496c826af8dbbca0 # v2.8.2
     permissions:
       contents: read
-    secrets: inherit
+    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       xcode-version: ${{ vars.XCODE_VERSION }}
@@ -60,7 +60,7 @@ jobs:
 
     permissions:
       contents: read
-    secrets: inherit
+    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       ipa-artifact-name: wallet-ios-demo-dev

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -40,7 +40,7 @@ jobs:
     uses: diggsweden/reusable-ci/.github/workflows/build-xcode-ios.yml@d31c989acd139c3e8754e116496c826af8dbbca0 # v2.8.2
     permissions:
       contents: read
-    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
+    secrets: inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       xcode-version: ${{ vars.XCODE_VERSION }}
@@ -60,7 +60,7 @@ jobs:
 
     permissions:
       contents: read
-    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
+    secrets: inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       ipa-artifact-name: wallet-ios-demo-dev

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       config: ${{ steps.generate.outputs.config }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Generate artifacts config with build number
         id: generate
         env:
@@ -54,7 +54,7 @@ jobs:
       attestations: write
       security-events: write
       actions: read
-    secrets: inherit
+    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       artifacts-config: ${{ needs.generate-artifacts-config.outputs.config }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -54,7 +54,7 @@ jobs:
       attestations: write
       security-events: write
       actions: read
-    secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
+    secrets: inherit
     with:
       reusable-ci-ref: d31c989acd139c3e8754e116496c826af8dbbca0
       artifacts-config: ${{ needs.generate-artifacts-config.outputs.config }}

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# secrets: inherit is intentional here — reusable-ci does not yet declare
+# explicit secrets in on.workflow_call.secrets, so it cannot be enumerated.
+# TODO: remove once diggsweden/reusable-ci exposes explicit secret declarations.
+.github/workflows/pull-request-workflow.yml
+.github/workflows/release-dev-workflow.yml
+.github/workflows/release-workflow.yml


### PR DESCRIPTION
# Pull Request Description

CI currently turns red due to unpinned commit hashes for actions. This PR fixes that.

Additionally, this PR adds a `.semgrepignore` to temporarily surpress the security warnings. Reusable CI is currently designed to pass inherited secrets, so we follow that pattern until it changes. The structure of `.semgrepignore` resembles the one that exists within https://github.com/diggsweden/wallet-provider
## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
