### PR TITLE
fix: mock asynchronous sleep for testing

### DIFF
--- a/Wallet/Core/Concurrency/SleepProviding.swift
+++ b/Wallet/Core/Concurrency/SleepProviding.swift
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Digg - Agency for digital government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import Foundation
+
+protocol SleepProviding: Sendable {
+  func sleep(for seconds: Double) async
+}
+
+struct SleepProvider: SleepProviding {
+  func sleep(for seconds: Double) async {
+    try? await Task.sleep(for: .seconds(seconds))
+  }
+}

--- a/Wallet/Features/Onboarding/WalletSetup/WalletSetupViewModel.swift
+++ b/Wallet/Features/Onboarding/WalletSetup/WalletSetupViewModel.swift
@@ -11,15 +11,18 @@ final class WalletSetupViewModel {
   private let pin: String
   private(set) var state: WalletSetupState = .idle
   private let onComplete: () -> Void
+  private let sleepProvider: any SleepProviding
 
   init(
     service: any WalletSetupService,
     pin: String,
     onComplete: @escaping () -> Void,
+    sleepProvider: any SleepProviding = SleepProvider(),
   ) {
     self.service = service
     self.pin = pin
     self.onComplete = onComplete
+    self.sleepProvider = sleepProvider
   }
 
   func setup() async {
@@ -38,7 +41,7 @@ final class WalletSetupViewModel {
     while let step = current {
       state = .working(step)
       do {
-        try? await Task.sleep(for: .seconds(.random(in: 0.5 ... 0.8)))
+        await sleepProvider.sleep(for: .random(in: 0.5 ... 0.8))
         current = try await perform(step)
       } catch {
         state = .failed(at: step, CaughtError(error))
@@ -46,7 +49,7 @@ final class WalletSetupViewModel {
       }
     }
     state = .complete
-    try? await Task.sleep(for: .seconds(1))
+    await sleepProvider.sleep(for: 1)
     onComplete()
   }
 

--- a/Wallet/Features/Onboarding/WalletSetup/WalletSetupViewModel.swift
+++ b/Wallet/Features/Onboarding/WalletSetup/WalletSetupViewModel.swift
@@ -41,7 +41,7 @@ final class WalletSetupViewModel {
     while let step = current {
       state = .working(step)
       do {
-        await sleepProvider.sleep(for: .random(in: 0.5 ... 0.8))
+        await sleepProvider.sleep(for: .random(in: Constants.randomStepDelayInSeconds))
         current = try await perform(step)
       } catch {
         state = .failed(at: step, CaughtError(error))
@@ -49,7 +49,7 @@ final class WalletSetupViewModel {
       }
     }
     state = .complete
-    await sleepProvider.sleep(for: 1)
+    await sleepProvider.sleep(for: Constants.onCompleteDelayInSeconds)
     onComplete()
   }
 
@@ -79,5 +79,12 @@ final class WalletSetupViewModel {
         try await service.saveKey(key: key)
         return nil
     }
+  }
+}
+
+private extension WalletSetupViewModel {
+  enum Constants {
+    static let onCompleteDelayInSeconds: Double = 1
+    static let randomStepDelayInSeconds: ClosedRange<Double> = 0.5 ... 0.8
   }
 }

--- a/WalletTests/Onboarding/WalletSetupViewModelTests.swift
+++ b/WalletTests/Onboarding/WalletSetupViewModelTests.swift
@@ -60,53 +60,82 @@ enum MockError: Error {
   case intentional
 }
 
+struct MockSleepProvider: SleepProviding {
+  func sleep(for seconds: Double) {}
+}
+
 // MARK: - Tests
 
 @MainActor
 struct WalletSetupViewModelTests {
   @Test
-  func `completes successfully`() async {
+  func completesSuccessfully() async {
     let service = MockWalletSetupService()
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: {})
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: {},
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
     #expect(vm.state == .complete)
   }
 
   @Test
-  func `calls onComplete on success`() async {
+  func callsonCompleteOnSuccess() async {
     var called = false
     let service = MockWalletSetupService()
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: { called = true })
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: { called = true },
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
     #expect(called)
   }
 
   @Test
-  func `does not call onComplete on failure`() async {
+  func doesNotCallonCompleteOnFailure() async {
     var called = false
     let service = MockWalletSetupService()
     service.failAt = .createAccount
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: { called = true })
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: { called = true },
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
     #expect(!called)
   }
 
   @Test
-  func `sets correct state on failure`() async throws {
+  func setsCorrectStateOnFailure() async throws {
     let service = MockWalletSetupService()
     let stretched = try PINStretch().stretch(input: Data("1234".utf8))
     service.failAt = .authenticate(stretched)
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: {})
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: {},
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
-    #expect(vm.state == .failed(at: .authenticate(stretched), error: MockError.intentional))
+    #expect(vm.state == .failed(at: .authenticate(stretched), CaughtError(MockError.intentional)))
   }
 
   @Test
-  func `retry resumes from failed step`() async throws {
+  func retryResumesFromFailedStep() async throws {
     let service = MockWalletSetupService()
     let stretched = try PINStretch().stretch(input: Data("1234".utf8))
     service.failAt = .authenticate(stretched)
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: {})
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: {},
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
 
     service.failAt = nil
@@ -120,9 +149,14 @@ struct WalletSetupViewModelTests {
   }
 
   @Test
-  func `retry does nothing if not failed`() async {
+  func retryDoesNothingIfNotFailed() async {
     let service = MockWalletSetupService()
-    let vm = WalletSetupViewModel(service: service, pin: "1234", onComplete: {})
+    let vm = WalletSetupViewModel(
+      service: service,
+      pin: "1234",
+      onComplete: {},
+      sleepProvider: MockSleepProvider(),
+    )
     await vm.setup()
     await vm.retry()
     #expect(service.createAccountCallCount == 1)

--- a/WalletTests/Onboarding/WalletSetupViewModelTests.swift
+++ b/WalletTests/Onboarding/WalletSetupViewModelTests.swift
@@ -82,7 +82,7 @@ struct WalletSetupViewModelTests {
   }
 
   @Test
-  func callsonCompleteOnSuccess() async {
+  func callsOnCompleteOnSuccess() async {
     var called = false
     let service = MockWalletSetupService()
     let vm = WalletSetupViewModel(
@@ -96,7 +96,7 @@ struct WalletSetupViewModelTests {
   }
 
   @Test
-  func doesNotCallonCompleteOnFailure() async {
+  func doesNotCallOnCompleteOnFailure() async {
     var called = false
     let service = MockWalletSetupService()
     service.failAt = .createAccount


### PR DESCRIPTION
# Pull Request Description

The `WalletSetupViewModel` adds artificial delay for UX-purposes. Tests were running slow due to them using the real asynchronous sleep. This PR adds a `SleepProviding` protocol that ensures we can mock these asynchronous operations with tests.

Additionally this PR fixes test names so they are consistent with the rest of tests in the codebase.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
