### PR TITLE
ci: run wallet gateway package tests via dedicated scheme

### DIFF
--- a/.github/actions/xcode-test/action.yml
+++ b/.github/actions/xcode-test/action.yml
@@ -34,7 +34,7 @@ runs:
         set -o pipefail
         xcodebuild test \
           -workspace Wallet.xcworkspace \
-          -scheme WalletGateway \
+          -scheme WalletGatewayTests \
           -destination 'platform=iOS Simulator,name=iPhone 17' \
           COMPILER_INDEX_STORE_ENABLE=NO \
         | xcbeautify

--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ test:
 # Run Swift package unit tests
 [group('build')]
 test-packages:
-    xcodebuild -workspace {{xcode_workspace}} -scheme WalletGateway -destination 'platform=iOS Simulator,name=iPhone 15' test
+    xcodebuild -workspace {{xcode_workspace}} -scheme WalletGatewayTests -destination 'platform=iOS Simulator,name=iPhone 15' test
 
 # Run UI tests
 [group('build')]

--- a/project.yml
+++ b/project.yml
@@ -229,3 +229,11 @@ schemes:
       targets:
         - WalletSnapshotTests
 
+  WalletGatewayTests:
+    build:
+      targets:
+        WalletDemo: none
+    test:
+      targets:
+        - package: WalletGateway/WalletGatewayTests
+


### PR DESCRIPTION
# Pull Request Description

The unit-test job in CI was failing:

```
 xcodebuild: error: Scheme WalletGateway is not currently configured for the test action.
```

`WalletGateway` is a local Swift package with a test target (`WalletGatewayTests`), but
  there was no scheme exposing the test action. This PR fixes that.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
